### PR TITLE
Deployment: Dockerfile and Smithery config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Start with a Node.js base image
+FROM node:18-alpine AS builder
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the entire source directory
+COPY src ./src
+
+# Build the project
+RUN npm run build
+
+# Start a new stage from the same Node.js image for the final build
+FROM node:18-alpine
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the built files from the previous stage
+COPY --from=builder /app/build ./build
+
+# Copy package.json and package-lock.json to ensure consistency in the final image
+COPY package.json package-lock.json ./
+
+# Install only production dependencies
+RUN npm ci --only=production
+
+# Specify the API key as an environment variable
+ENV SYSTEMPROMPT_API_KEY=YOUR_API_KEY_HERE
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Define the command to run the application
+CMD ["node", "build/index.js"]

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,19 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+build:
+  dockerBuildPath: .
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - systempromptApiKey
+    properties:
+      systempromptApiKey:
+        type: string
+        description: The API key for the systemprompt-agent-server.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command: 'node', args: ['./build/index.js'], env: {SYSTEMPROMPT_API_KEY: config.systempromptApiKey}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Dockerfile**: Introduces a Dockerfile to package the MCP for deployment across various environments.
- **Smithery Configuration**: Adds a Smithery YAML configuration file, which specifies how to start the MCP and what configuration options it supports. This enables hosting the MCP server on [Smithery](https://smithery.ai) and allows users to connect to the hosted version over SSE without additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/systemprompt-agent-server) and claiming it.

Please review these updates to verify their accuracy for your server. Let us know if you have any questions. 🙂